### PR TITLE
Add `User-Agent` header

### DIFF
--- a/chess_com_box.py
+++ b/chess_com_box.py
@@ -52,7 +52,10 @@ def get_adjusted_line(title_and_value: TitleAndValue, max_line_length: int) -> s
 
 
 def get_chess_com_stats(user: str = "sciencepal") -> dict:
-    stats_dict = requests.get(STATS_URL.format(user=user)).json()
+    headers = {
+        'User-Agent': f'chess-com-box-py @{user}'
+    }
+    stats_dict = requests.get(STATS_URL.format(user=user), headers=headers).json()
     return stats_dict
 
 


### PR DESCRIPTION
Chess.com now requires contact information while making HTTP requests to their API.

https://www.chess.com/announcements/view/breaking-change-user-agent-contact-info-required

Here I added  `User-Agent` HTTP header with the username to the request.